### PR TITLE
Export struct as interface and remove trailing semicolon for enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "typescript-definitions-ufo-patch"
+name = "typescript-definitions"
 version = "0.1.10"
 description = "serde support for exporting Typescript definitions"
 readme = "README.md"

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,0 +1,15 @@
+use serde::Serialize;
+use typescript_definitions::{TypeScriptify, TypeScriptifyTrait};
+
+#[test]
+fn serialize_enum() {
+    #[derive(Serialize, TypeScriptify)]
+    enum TestEnum {
+        VariantA,
+        VariantB
+    }
+
+    let result = TestEnum::type_script_ify();
+
+    assert_eq!(result, r#"export enum TestEnum { VariantA = "VariantA", VariantB = "VariantB" }"#);
+}

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,3 +1,5 @@
+#[allow(unused)]
+
 use serde::Serialize;
 use typescript_definitions::{TypeScriptify, TypeScriptifyTrait};
 
@@ -12,4 +14,53 @@ fn serialize_enum() {
     let result = TestEnum::type_script_ify();
 
     assert_eq!(result, r#"export enum TestEnum { VariantA = "VariantA", VariantB = "VariantB" }"#);
+}
+
+#[test]
+fn serialize_enum_variants() {
+    let expected = concat!("export type Enum = ", '\n', r#" | { V1: { Foo: boolean } } "#, '\n', r#" | { V2: { Bar: number; Baz: number } } "#, '\n', r#" | { V3: { Quux: string } };"#);
+    #[derive(Serialize, TypeScriptify)]
+    pub enum Enum {
+        V1 {
+            #[serde(rename = "Foo")]
+            foo: bool,
+        },
+        V2 {
+            #[serde(rename = "Bar")]
+            bar: i64,
+            #[serde(rename = "Baz")]
+            baz: u64,
+        },
+        V3 {
+            #[serde(rename = "Quux")]
+            quux: String,
+        },
+    }
+
+    let result = Enum::type_script_ify();
+
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn serialize_complex_enum() {
+    let expected = concat!("export type S = ", '\n', r#" | { kind: "A" } "#, '\n', r#" | { kind: "E2"; fields: { key: number; a: number } } "#, '\n', r#" | { kind: "F"; fields: [number, string] };"#);
+    #[derive(Serialize, TypeScriptify)]
+    #[serde(tag = "kind", content = "fields")]
+    enum S {
+        A,
+        E2 {
+            key: i32,
+            a: i32,
+            #[serde(skip)]
+            b: f64,
+        },
+        F(i32, #[serde(skip)] f64, String),
+        #[serde(skip)]
+        Z,
+    }
+
+    let result = S::type_script_ify();
+
+    assert_eq!(result, expected)
 }

--- a/tests/structs.rs
+++ b/tests/structs.rs
@@ -1,0 +1,57 @@
+#[allow(unused)]
+
+use serde::Serialize;
+
+use typescript_definitions::{TypeScriptify, TypeScriptifyTrait};
+
+#[test]
+fn serialize_basic_struct() {
+    #[derive(Serialize, TypeScriptify, Debug)]
+    pub struct Point {
+        #[serde(rename = "X")]
+        pub x: i64,
+        #[serde(rename = "Y")]
+        pub y: i64,
+        pub z: i64,
+    }
+
+    let result = Point::type_script_ify();
+
+    assert_eq!(result, r#"export interface Point { X: number; Y: number; z: number; }"#);
+}
+
+#[test]
+fn serialize_unit_struct() {
+    #[derive(Serialize, TypeScriptify)]
+    pub struct Newtype(pub i64);
+
+    let result = Newtype::type_script_ify();
+
+    assert_eq!(result, r#"export type Newtype = number;"#)
+}
+
+#[test]
+fn serialize_generic_struct() {
+    #[derive(Serialize, TypeScriptify)]
+    pub struct Value<T : ToString> {
+        value: T,
+    }
+
+    let result = Value::<String>::type_script_ify();
+
+    assert_eq!(result, r#"export interface Value<T> { value: T; }"#)
+}
+
+#[test]
+fn serialize_byte_string() {
+    #[derive(Serialize, TypeScriptify)]
+    pub struct MyBytes {
+        #[serde(serialize_with = "typescript_definitions::as_byte_string")]
+        pub buffer: Vec<u8>,
+
+    }
+
+    let result = MyBytes::type_script_ify();
+
+    assert_eq!(result, r#"export interface MyBytes { buffer: string; }"#)
+}

--- a/typescript-definitions-derive/src/derive_enum.rs
+++ b/typescript-definitions-derive/src/derive_enum.rs
@@ -91,6 +91,7 @@ impl<'a> ParseContext<'_> {
                 body: quote! ( { #(#k = #v),* } ),
                 verify,
                 is_enum: true,
+                is_interface: false,
             };
         }
 
@@ -132,6 +133,7 @@ impl<'a> ParseContext<'_> {
             body: quote! ( #( #nl | #body)* ),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
     fn derive_unit_variant(&self, taginfo: &TagInfo, variant: &Variant) -> QuoteMaker {
@@ -153,6 +155,7 @@ impl<'a> ParseContext<'_> {
                 body: quote!(#variant_name),
                 verify,
                 is_enum: false,
+                is_interface: false,
             };
         }
         let tag = ident_from_str(taginfo.tag.unwrap());
@@ -172,6 +175,7 @@ impl<'a> ParseContext<'_> {
             ),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
 
@@ -201,6 +205,7 @@ impl<'a> ParseContext<'_> {
                     body: quote! ( #ty ),
                     verify,
                     is_enum: false,
+                    is_interface: false,
                 };
             };
             let tag = ident_from_str(&variant_name);
@@ -229,6 +234,7 @@ impl<'a> ParseContext<'_> {
                 ),
                 verify,
                 is_enum: false,
+                is_interface: false,
             };
         };
         let tag = ident_from_str(taginfo.tag.unwrap());
@@ -259,6 +265,7 @@ impl<'a> ParseContext<'_> {
             ),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
 
@@ -302,6 +309,7 @@ impl<'a> ParseContext<'_> {
                     ),
                     verify,
                     is_enum: false,
+                    is_interface: false,
                 };
             };
             let v = &quote!(v);
@@ -326,6 +334,7 @@ impl<'a> ParseContext<'_> {
                 ),
                 verify,
                 is_enum: false,
+                is_interface: false,
             };
         }
         let tag_str = taginfo.tag.unwrap();
@@ -358,6 +367,7 @@ impl<'a> ParseContext<'_> {
                 ),
                 verify,
                 is_enum: false,
+                is_interface: false,
             }
         } else {
             if let Some(ref cx) = self.ctxt {
@@ -393,6 +403,7 @@ impl<'a> ParseContext<'_> {
                 ),
                 verify,
                 is_enum: false,
+                is_interface: false,
             }
         }
     }
@@ -434,6 +445,7 @@ impl<'a> ParseContext<'_> {
                     ),
                     verify,
                     is_enum: false,
+                    is_interface: false,
                 };
             }
             let tag = ident_from_str(&variant_name);
@@ -459,6 +471,7 @@ impl<'a> ParseContext<'_> {
                 ),
                 verify,
                 is_enum: false,
+                is_interface: false,
             };
         };
 
@@ -491,6 +504,7 @@ impl<'a> ParseContext<'_> {
             ),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
 }

--- a/typescript-definitions-derive/src/derive_struct.rs
+++ b/typescript-definitions-derive/src/derive_struct.rs
@@ -48,6 +48,7 @@ impl<'a> ParseContext<'_> {
             body: self.field_to_ts(field),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
 
@@ -62,6 +63,7 @@ impl<'a> ParseContext<'_> {
             body: quote!({}),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
 
@@ -93,9 +95,10 @@ impl<'a> ParseContext<'_> {
         };
 
         QuoteMaker {
-            body: quote!({ #(#content);* }),
+            body: quote!({ #(#content);*; }),
             verify,
             is_enum: false,
+            is_interface: true,
         }
     }
 
@@ -134,6 +137,7 @@ impl<'a> ParseContext<'_> {
             body: quote!([#(#content),*]),
             verify,
             is_enum: false,
+            is_interface: false,
         }
     }
 }

--- a/typescript-definitions-derive/src/lib.rs
+++ b/typescript-definitions-derive/src/lib.rs
@@ -200,7 +200,7 @@ impl Typescriptify {
     fn wasm_string(&self) -> String {
         if self.body.is_enum {
             format!(
-                "{}export enum {} {};",
+                "{}export enum {} {}",
                 self.ctxt.global_attrs.to_comment_str(),
                 self.ts_ident_str(),
                 self.ts_body_str()

--- a/typescript-definitions-derive/src/lib.rs
+++ b/typescript-definitions-derive/src/lib.rs
@@ -46,6 +46,7 @@ struct QuoteMaker {
     pub body: QuoteT,
     pub verify: Option<QuoteT>,
     pub is_enum: bool,
+    pub is_interface: bool
 }
 #[allow(unused)]
 fn is_wasm32() -> bool {
@@ -201,6 +202,13 @@ impl Typescriptify {
         if self.body.is_enum {
             format!(
                 "{}export enum {} {}",
+                self.ctxt.global_attrs.to_comment_str(),
+                self.ts_ident_str(),
+                self.ts_body_str()
+            )
+        } else if self.body.is_interface {
+            format!(
+                "{}export interface {} {}",
                 self.ctxt.global_attrs.to_comment_str(),
                 self.ts_ident_str(),
                 self.ts_body_str()


### PR DESCRIPTION
I've added some tests, fixed typescript compatibility with enums and expose structs as interface when possible.